### PR TITLE
[ENG-1644] bug overwrite cassette

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aikon/network-vcr",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Simple tool for recording and playing back network requests in tests",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/src/VCR.test.ts
+++ b/src/VCR.test.ts
@@ -176,4 +176,18 @@ describe('VCR', () => {
     cassettes = await getAllCassettes()
     expect(before).toEqual(cassettes['VCR Should not clear current cassette'])
   })
+
+  it('Should not update an existing cassette', async () => {
+    let cassettes = await getAllCassettes()
+    const before = cassettes['VCR Should not update an existing cassette']
+    expect(before).toHaveLength(1)
+
+    await startVCR({ CI: false }) // we want make the real request, even on CI
+    await fetch('http://example.com')
+    await expect(fetch('http://example.com')).rejects.toThrow()
+    await stopVCR()
+
+    cassettes = await getAllCassettes()
+    expect(before).toEqual(cassettes['VCR Should not update an existing cassette'])
+  })
 })

--- a/src/VCR.ts
+++ b/src/VCR.ts
@@ -62,10 +62,11 @@ async function writeCassetteFile(cassettes: CassetteFile): Promise<void> {
 async function saveCassettes(defns: nock.Definition[]): Promise<void> {
   const cassettes: CassetteFile = await readCassetteFile()
   const testName = expect.getState().currentTestName
+
   if (!testName) return
 
-  const hasCasset = cassettes[testName] && !!cassettes[testName].length
-  if (!defns.length && hasCasset) return
+  // we should only update a casset to a empty array when has no cassette to this test
+  if (defns.length === 0 && typeof cassettes[testName] !== 'undefined') return
 
   cassettes[testName] = defns
   await writeCassetteFile(cassettes)

--- a/src/__cassettes__/VCR.cassette.json
+++ b/src/__cassettes__/VCR.cassette.json
@@ -583,5 +583,48 @@
       ],
       "responseIsBinary": false
     }
+  ],
+  "VCR Should not update an existing cassette": [
+    {
+      "scope": "http://example.com:80",
+      "method": "GET",
+      "path": "/",
+      "body": "",
+      "status": 200,
+      "response": [
+        "1f8b08000000000000ff7d544d73db2010bdfb576cd54b32232427691a8f2d69fa99690f690f690f3d12b1b298085001c9f674f2dfbb428e2337999a91815d78bbefb190bd12a6f4bb16a1f6aa2966d963875c1433a05fe6a56fb0f8bce5aa6d103e19c5a5ced2d13a1b9728f41cca9a5b873e8f3a5fb14504693171d6deb70c7f77b2cfa38f467bd49e0d612328c7591e79dcfa7408bf3a40bd84a4b9c23cea256e5a63fd64ff460a5fe7027b59220b9318a4965ef286b99237989f3d4139bf23324306fbc0a573d1e8bb3362077fc2304c7979bfb6a6d38295a6317609afab39b5f3d56189e2762df512e64fa6960b21f5fac85651a6ace24a36bb2530de929ccced9c4715c3d8b34ec6f0a191fafe8697b7c1744d9b62886e716d107e7e8d68fcbd450db75cbb61f2059b1ebd2c397cc30ec97230c4f0de1277c2a6a5cca195d5532e61f010fe85ec277483704b783b9fb7dbe70c2f5101efbc7981e839aad57f4513d42619dc192bd032cb85ec1ce9945c1e01982d7335176643c8ed162ee8bba26f18dbf51d3f99c7a125f3f3d3d5840c5f0eeac5d4f7d2498f6242ed31938bc59bc56292c970fe4c60692cf7d2104b6d344e41df291492c389e25bb6d7e76ad0e774027eace25155fca3d844e563c7c3246496860a2dc25965e9781d67d9509b743b29d8be8eebb36737934ca3af2d7ed4d2810876a051652c740e6198354de7fc40b847c011c10d0e7a0e3a45f7c925f0cb74446217b678421aab658fa6a1217909a0b348747c6d3a0fad9514a23474b452073181e6dcdd538584e82d5a259d234792a5ed21cf8c1e088b551e0dcf845ba6e966b34924d73c31769d8e215dba4f332a6e8c1d4810a00a419284d0781110b3348893a57ba9d2f141fb0b28eb7c6fe8040000"
+      ],
+      "rawHeaders": [
+        "Content-Encoding",
+        "gzip",
+        "Accept-Ranges",
+        "bytes",
+        "Age",
+        "289132",
+        "Cache-Control",
+        "max-age=604800",
+        "Content-Type",
+        "text/html; charset=UTF-8",
+        "Date",
+        "Fri, 04 Nov 2022 19:14:28 GMT",
+        "Etag",
+        "\"3147526947\"",
+        "Expires",
+        "Fri, 11 Nov 2022 19:14:28 GMT",
+        "Last-Modified",
+        "Thu, 17 Oct 2019 07:18:26 GMT",
+        "Server",
+        "ECS (mic/9B35)",
+        "Vary",
+        "Accept-Encoding",
+        "X-Cache",
+        "HIT",
+        "Content-Length",
+        "648",
+        "Connection",
+        "close"
+      ],
+      "responseIsBinary": false
+    }
   ]
 }

--- a/src/__cassettes__/VCR.cassette.json
+++ b/src/__cassettes__/VCR.cassette.json
@@ -626,5 +626,48 @@
       ],
       "responseIsBinary": false
     }
+  ],
+  "VCR Should not cahnge a current cassette if the requests change": [
+    {
+      "scope": "http://example.com:80",
+      "method": "GET",
+      "path": "/",
+      "body": "",
+      "status": 200,
+      "response": [
+        "1f8b08000000000000ff7d544d73db2010bdfb576cd54b32232427691a8f2d69fa99690f690f690f3d12b1b298085001c9f674f2dfbb428e2337999a91815d78bbefb190bd12a6f4bb16a1f6aa2966d963875c1433a05fe6a56fb0f8bce5aa6d103e19c5a5ced2d13a1b9728f41cca9a5b873e8f3a5fb14504693171d6deb70c7f77b2cfa38f467bd49e0d612328c7591e79dcfa7408bf3a40bd84a4b9c23cea256e5a63fd64ff460a5fe7027b59220b9318a4965ef286b99237989f3d4139bf23324306fbc0a573d1e8bb3362077fc2304c7979bfb6a6d38295a6317609afab39b5f3d56189e2762df512e64fa6960b21f5fac85651a6ace24a36bb2530de929ccced9c4715c3d8b34ec6f0a191fafe8697b7c1744d9b62886e716d107e7e8d68fcbd450db75cbb61f2059b1ebd2c397cc30ec97230c4f0de1277c2a6a5cca195d5532e61f010fe85ec277483704b783b9fb7dbe70c2f5101efbc7981e839aad57f4513d42619dc192bd032cb85ec1ce9945c1e01982d7335176643c8ed162ee8bba26f18dbf51d3f99c7a125f3f3d3d5840c5f0eeac5d4f7d2498f6242ed31938bc59bc56292c970fe4c60692cf7d2104b6d344e41df291492c389e25bb6d7e76ad0e774027eace25155fca3d844e563c7c3246496860a2dc25965e9781d67d9509b743b29d8be8eebb36737934ca3af2d7ed4d2810876a051652c740e6198354de7fc40b847c011c10d0e7a0e3a45f7c925f0cb74446217b678421aab658fa6a1217909a0b348747c6d3a0fad9514a23474b452073181e6dcdd538584e82d5a259d234792a5ed21cf8c1e088b551e0dcf845ba6e966b34924d73c31769d8e215dba4f332a6e8c1d4810a00a419284d0781110b3348893a57ba9d2f141fb0b28eb7c6fe8040000"
+      ],
+      "rawHeaders": [
+        "Content-Encoding",
+        "gzip",
+        "Accept-Ranges",
+        "bytes",
+        "Age",
+        "289132",
+        "Cache-Control",
+        "max-age=604800",
+        "Content-Type",
+        "text/html; charset=UTF-8",
+        "Date",
+        "Fri, 04 Nov 2022 19:14:28 GMT",
+        "Etag",
+        "\"3147526947\"",
+        "Expires",
+        "Fri, 11 Nov 2022 19:14:28 GMT",
+        "Last-Modified",
+        "Thu, 17 Oct 2019 07:18:26 GMT",
+        "Server",
+        "ECS (mic/9B35)",
+        "Vary",
+        "Accept-Encoding",
+        "X-Cache",
+        "HIT",
+        "Content-Length",
+        "648",
+        "Connection",
+        "close"
+      ],
+      "responseIsBinary": false
+    }
   ]
 }

--- a/src/__cassettes__/VCR.cassette.json
+++ b/src/__cassettes__/VCR.cassette.json
@@ -540,5 +540,48 @@
   ],
   "VCR CI should accept empty a cassette": [],
   "VCR an empty cassette must be filled when a request is made": [],
-  "VCR CI should not update a empty cassette": []
+  "VCR CI should not update a empty cassette": [],
+  "VCR Should not clear current cassette": [
+    {
+      "scope": "http://example.com:80",
+      "method": "GET",
+      "path": "/",
+      "body": "",
+      "status": 200,
+      "response": [
+        "1f8b08000000000000ff7d544d73db2010bdfb576cd54b32232427691a8f2d69fa99690f690f690f3d12b1b298085001c9f674f2dfbb428e2337999a91815d78bbefb190bd12a6f4bb16a1f6aa2966d963875c1433a05fe6a56fb0f8bce5aa6d103e19c5a5ced2d13a1b9728f41cca9a5b873e8f3a5fb14504693171d6deb70c7f77b2cfa38f467bd49e0d612328c7591e79dcfa7408bf3a40bd84a4b9c23cea256e5a63fd64ff460a5fe7027b59220b9318a4965ef286b99237989f3d4139bf23324306fbc0a573d1e8bb3362077fc2304c7979bfb6a6d38295a6317609afab39b5f3d56189e2762df512e64fa6960b21f5fac85651a6ace24a36bb2530de929ccced9c4715c3d8b34ec6f0a191fafe8697b7c1744d9b62886e716d107e7e8d68fcbd450db75cbb61f2059b1ebd2c397cc30ec97230c4f0de1277c2a6a5cca195d5532e61f010fe85ec277483704b783b9fb7dbe70c2f5101efbc7981e839aad57f4513d42619dc192bd032cb85ec1ce9945c1e01982d7335176643c8ed162ee8bba26f18dbf51d3f99c7a125f3f3d3d5840c5f0eeac5d4f7d2498f6242ed31938bc59bc56292c970fe4c60692cf7d2104b6d344e41df291492c389e25bb6d7e76ad0e774027eace25155fca3d844e563c7c3246496860a2dc25965e9781d67d9509b743b29d8be8eebb36737934ca3af2d7ed4d2810876a051652c740e6198354de7fc40b847c011c10d0e7a0e3a45f7c925f0cb74446217b678421aab658fa6a1217909a0b348747c6d3a0fad9514a23474b452073181e6dcdd538584e82d5a259d234792a5ed21cf8c1e088b551e0dcf845ba6e966b34924d73c31769d8e215dba4f332a6e8c1d4810a00a419284d0781110b3348893a57ba9d2f141fb0b28eb7c6fe8040000"
+      ],
+      "rawHeaders": [
+        "Content-Encoding",
+        "gzip",
+        "Accept-Ranges",
+        "bytes",
+        "Age",
+        "289132",
+        "Cache-Control",
+        "max-age=604800",
+        "Content-Type",
+        "text/html; charset=UTF-8",
+        "Date",
+        "Fri, 04 Nov 2022 19:14:28 GMT",
+        "Etag",
+        "\"3147526947\"",
+        "Expires",
+        "Fri, 11 Nov 2022 19:14:28 GMT",
+        "Last-Modified",
+        "Thu, 17 Oct 2019 07:18:26 GMT",
+        "Server",
+        "ECS (mic/9B35)",
+        "Vary",
+        "Accept-Encoding",
+        "X-Cache",
+        "HIT",
+        "Content-Length",
+        "648",
+        "Connection",
+        "close"
+      ],
+      "responseIsBinary": false
+    }
+  ]
 }


### PR DESCRIPTION
My last changes introduced a bug. When running the tests (using the VCR) I was erasing the existing cassettes by "[]".
This PR is fixing this bug. Now only when not listening to cassette for a test will put a "[]"